### PR TITLE
replace start button with a regular link

### DIFF
--- a/colournaming/static/css/styles.css
+++ b/colournaming/static/css/styles.css
@@ -120,12 +120,15 @@ h3 ~ .justified-text {
     cursor: pointer;
     display: block;
     font-size: 35px;
-    height: 127px;
+    height: 123px;
+    line-height: 123px;
     margin: 1em auto;
     outline: none;
     padding: 0;
     position: relative;
-    width: 127px;
+    text-align: center;
+    text-decoration: none;
+    width: 123px;
 }
 
 .round-button::before {
@@ -142,9 +145,9 @@ h3 ~ .justified-text {
 
 .round-button:hover {
     border-radius: 64.5px;
-    height: 125px;
+    height: 121px;
     margin: calc(1em + 1px) auto;
-    width: 125px;
+    width: 121px;
 }
 
 .round-button:hover::before {
@@ -154,9 +157,9 @@ h3 ~ .justified-text {
 
 .round-button:active {
     border-radius: 64.5px;
-    height: 125px;
+    height: 121px;
     margin: calc(1em + 2px) auto 1em;
-    width: 125px;
+    width: 121px;
 }
 
 .round-button:active::before {

--- a/colournaming/templates/index.html
+++ b/colournaming/templates/index.html
@@ -19,7 +19,7 @@
         <p class="justified-text">The participation in this study is only for over 16 years old and voluntary. Please note that you may withdraw at any time without any penalty.</p>
         <h3>Agreement:</h3>
         <p class="justified-text">{{ _('By clicking Start you confirm that you have understood the provided information and agree to take part in this study.') }}</p>
-        <button class="round-button">Start</button>
+        <a class="round-button" href="{{ url_for('experiment.start') }}">Start</a>
     </section>
     <section>
         <h2 id="colour-namer">


### PR DESCRIPTION
This little pull request just turns the start <button/> into a <a/> element.