### PR TITLE
Initialize the database before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - docker-compose up -d postgres
 
 script:
-  - docker-compose run --rm --entrypoint "pytest tests" web
+  - docker-compose run --rm web test
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/colournaming/__init__.py
+++ b/colournaming/__init__.py
@@ -3,6 +3,7 @@
 import click
 from flask import Flask, render_template, request, current_app
 from flask_babel import Babel
+import pytest
 from sqlalchemy.exc import ProgrammingError
 import user_agents
 from .database import db
@@ -81,6 +82,11 @@ def setup_cli(app):
     def dropdb():
         """Drop database tables."""
         db.drop_all()
+
+    @app.cli.command()
+    def test():
+        """Run the test suite."""
+        pytest.main(['tests'])
 
     @app.cli.command()
     @click.pass_context

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1,8 +1,31 @@
+import pytest
 from colournaming import create_app
+from colournaming.database import db
+from colournaming.experiment import model as experiment_model
+from colournaming.namer import model as namer_model
 
 
-def test_homepage():
+@pytest.fixture(scope='module')
+def database():
+    """Initialize the database and drop it when finished."""
+    db.create_all()
+    tgt = experiment_model.ColourTarget(id=100, red=255, green=0, blue=0)
+    db.session.add(tgt)
+    lang_en = namer_model.Language(name='English', code='en')
+    lang_fr = namer_model.Language(name='French', code='fr')
+    db.session.add(lang_en)
+    db.session.add(lang_fr)
+    yield
+    db.drop_all()
+
+
+@pytest.fixture(scope='module')
+def client():
+    """Create a Flask test client."""
     app = create_app()
-    tc = app.test_client()
-    rv = tc.get('/')
+    return app.test_client()
+
+
+def test_homepage(database, client):
+    rv = client.get('/')
     assert b'ColourNaming' in rv.data


### PR DESCRIPTION
Adds a test command to the CLI and sets up the database before testing (also tears it down afterwards). Fixes #35.