### PR TITLE
only play loaded buffers

### DIFF
--- a/colournaming/static/js/audio.js
+++ b/colournaming/static/js/audio.js
@@ -56,11 +56,14 @@ function loadSound(url, sampleId) {
 function playSound(hexcode) {
     var sampleId = hexcode.substr(1);
     var source = context.createBufferSource();
-    source.buffer = sampleBuffers[sampleId];
-    source.connect(context.destination);
-	try {
-		source.start(0);
-	} catch(e) {
-		source.noteOn(0);
-	}
+
+    if (sampleBuffers[sampleId] !== undefined) {
+        source.buffer = sampleBuffers[sampleId];
+        source.connect(context.destination);
+        try {
+            source.start(0)
+        } catch(e) {
+            source.noteOn(0);
+        }
+    }
 }


### PR DESCRIPTION
This pull request makes sure that only loaded buffers are actually played. That will preserve a possible error in Chrome and maybe also fix #41.