### PR TITLE
Handle IndexError when checking browser language

### DIFF
--- a/colournaming/experiment/views.py
+++ b/colournaming/experiment/views.py
@@ -16,11 +16,15 @@ def check_in_experiment():
 def start():
     """Show the experiment start page."""
     print('resetting experiment')
+    try:
+        browser_language = request.accept_languages[0][0]
+    except IndexError:
+        browser_language = None
     session['experiment'] = {
         'client': {
             'ip_address': request.remote_addr,
             'user_agent': request.user_agent.string,
-            'browser_language': request.accept_languages[0][0]
+            'browser_language': browser_language
         }
     }
     return redirect(url_for('experiment.display_properties'))


### PR DESCRIPTION
If an IndexError occurs while accessing request.accept_languages then set browser_language to None and carry on.  Fixes #56.