### PR TITLE
implement contact form feedback

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -267,6 +267,11 @@ h3 ~ .justified-text {
     color: #0F52BA;
 }
 
+#contact-error-message,
+#contact-success-message {
+    display: none;
+}
+
 form {
     margin: 1em auto 2.5em;
     max-width: 680px;

--- a/assets/js/colour-namer.js
+++ b/assets/js/colour-namer.js
@@ -147,4 +147,35 @@ $(function () {
   updateLanguages();
   updateNames();
   initAudio();
+
+  const $contactForm = $('#contact_form');
+  const $contactFormErrorMessage = $('#contact-error-message');
+  const $contactFormSuccessMessage = $('#contact-success-message');
+  const $contactFormSubmitButton = $contactForm.find('button[type=submit]');
+
+  $contactForm.submit((event) => {
+    event.preventDefault();
+
+    $contactFormErrorMessage.hide();
+    $contactFormSuccessMessage.hide();
+    $contactFormSubmitButton.prop('disabled', true);
+
+    const formData = new FormData($contactForm.get(0));
+
+    fetch(window.location, {
+      body: formData,
+      credentials: 'same-origin',
+      method: 'POST'
+    })
+      .then((response) => {
+        if (response.ok) {
+          $contactForm[0].reset();
+          $contactFormSuccessMessage.show();
+        } else {
+          $contactFormErrorMessage.show();
+        }
+
+        $contactFormSubmitButton.prop('disabled', false);
+      });
+  });
 })

--- a/colournaming/templates/index.html
+++ b/colournaming/templates/index.html
@@ -283,6 +283,8 @@
         <p class="justified-text">Please use the following communication form
         to give us your feedback and comments or if you wish to inform you
         about the results of this research.</p>
+        <p id="contact-error-message" class="justified-text"><!-- ... the error message --></p>
+        <p id="contact-success-message" class="justified-text"><!-- ... the success message --></p>
         <form id='contact_form' method="post">
             {{ contact_form.csrf_token }}
             {{ contact_form.first_name.label(for='first_name') }}


### PR DESCRIPTION
This pull request implements the basic feedback logic for the contact form. The actual messages are not included but there are placeholders for each message in the template.

It's meant to fix #100.